### PR TITLE
feat: add payment screen

### DIFF
--- a/Scrum/sprints/uvgride/frontend/src/navigation/Navigation.tsx
+++ b/Scrum/sprints/uvgride/frontend/src/navigation/Navigation.tsx
@@ -11,6 +11,7 @@ import FavoriteScreen from '../screens/FavoriteScreen';
 import AddFavoriteScreen from '../screens/AddFavoriteScreen';
 import ScheduledTripScreen from '../screens/ScheduledTripScreen';
 import VehicleFormScreen from '../screens/VehicleFormScreen';
+import PaymentScreen from '../screens/PaymentScreen';
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
 
@@ -32,6 +33,9 @@ export default function Navigation() {
       {/* Favoritos (nombres alineados con el type) */}
       <Stack.Screen name="Favorite" component={FavoriteScreen} />
       <Stack.Screen name="AddFavorite" component={AddFavoriteScreen} />
+
+      {/* Pagos */}
+      <Stack.Screen name="Payment" component={PaymentScreen} />
 
       {/* Vehículos (si lo usas desde Perfil) */}
       <Stack.Screen name="VehicleForm" component={VehicleFormScreen} />

--- a/Scrum/sprints/uvgride/frontend/src/navigation/RootStack.tsx
+++ b/Scrum/sprints/uvgride/frontend/src/navigation/RootStack.tsx
@@ -12,6 +12,7 @@ import ScheduledTripScreen from '../screens/ScheduledTripScreen';
 import DriverProfileScreen from '../screens/DriverProfileScreen';
 import GroupCreateScreen from '../screens/GroupCreateScreen';
 import { useUser } from '../context/UserContext';
+import PaymentScreen from '../screens/PaymentScreen';
 import { RootStackParamList } from './type';
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
@@ -35,6 +36,7 @@ export default function RootStack() {
           <Stack.Screen name="VehicleForm" component={VehicleFormScreen} />
           <Stack.Screen name="ScheduledTripScreen" component={ScheduledTripScreen} />
           <Stack.Screen name="GroupCreate" component={GroupCreateScreen} />
+          <Stack.Screen name="Payment" component={PaymentScreen} />
           {/* 👇 Detalle del conductor */}
           <Stack.Screen name="DriverProfile" component={DriverProfileScreen} />
         </Stack.Group>

--- a/Scrum/sprints/uvgride/frontend/src/navigation/type.tsx
+++ b/Scrum/sprints/uvgride/frontend/src/navigation/type.tsx
@@ -35,6 +35,9 @@ export type RootStackParamList = {
 
   ScheduledTripScreen: undefined;
 
+  // Pagos
+  Payment: undefined;
+
   // Conductores
   DriverProfile: { driverId: number };
 

--- a/Scrum/sprints/uvgride/frontend/src/screens/PaymentScreen.tsx
+++ b/Scrum/sprints/uvgride/frontend/src/screens/PaymentScreen.tsx
@@ -1,0 +1,83 @@
+import React, { useState } from 'react';
+import { View, Text, TextInput, Button, StyleSheet, Alert } from 'react-native';
+import { Picker } from '@react-native-picker/picker';
+import { createPayment } from '../services/payments';
+import { useUser } from '../context/UserContext';
+
+export default function PaymentScreen() {
+  const { user } = useUser();
+  const [amount, setAmount] = useState('');
+  const [method, setMethod] = useState<'efectivo' | 'tarjeta'>('efectivo');
+  const [loading, setLoading] = useState(false);
+
+  const handlePay = async () => {
+    if (!user?.id) {
+      Alert.alert('Error', 'Usuario no autenticado');
+      return;
+    }
+    const value = parseFloat(amount);
+    if (isNaN(value)) {
+      Alert.alert('Error', 'Monto inválido');
+      return;
+    }
+    setLoading(true);
+    try {
+      const payment = await createPayment({
+        userId: user.id,
+        amount: value,
+        method,
+      });
+      Alert.alert('Pago creado', `Estado: ${payment.status}`);
+    } catch (e) {
+      console.error(e);
+      Alert.alert('Error', 'No se pudo procesar el pago');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.label}>Monto</Text>
+      <TextInput
+        style={styles.input}
+        value={amount}
+        onChangeText={setAmount}
+        keyboardType="numeric"
+        placeholder="0.00"
+      />
+      <Text style={styles.label}>Método de pago</Text>
+      <Picker selectedValue={method} onValueChange={v => setMethod(v)} style={styles.picker}>
+        <Picker.Item label="Efectivo" value="efectivo" />
+        <Picker.Item label="Tarjeta" value="tarjeta" />
+      </Picker>
+      <Button title={loading ? 'Procesando...' : 'Pagar'} onPress={handlePay} disabled={loading} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 20,
+    justifyContent: 'center',
+    backgroundColor: '#f5f5f5',
+  },
+  label: {
+    marginBottom: 8,
+    fontSize: 16,
+    fontWeight: 'bold',
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: '#ccc',
+    padding: 10,
+    borderRadius: 8,
+    marginBottom: 16,
+    backgroundColor: '#fff',
+  },
+  picker: {
+    marginBottom: 24,
+  },
+});
+

--- a/Scrum/sprints/uvgride/frontend/src/services/payments.ts
+++ b/Scrum/sprints/uvgride/frontend/src/services/payments.ts
@@ -1,0 +1,30 @@
+import axios from 'axios';
+import { API_URL } from './api';
+
+export type Payment = {
+  id: number;
+  userId: number;
+  amount: number;
+  method: 'efectivo' | 'tarjeta';
+  status: string;
+};
+
+export async function createPayment(payload: {
+  userId: number;
+  amount: number;
+  method: 'efectivo' | 'tarjeta';
+}) {
+  const res = await axios.post(`${API_URL}/api/pagos`, payload);
+  return res.data;
+}
+
+export async function getPayments() {
+  const res = await axios.get(`${API_URL}/api/pagos`);
+  return res.data;
+}
+
+export async function getPayment(id: number) {
+  const res = await axios.get(`${API_URL}/api/pagos/${id}`);
+  return res.data;
+}
+

--- a/Scrum/sprints/uvgride/frontend/test/PaymentScreen.test.tsx
+++ b/Scrum/sprints/uvgride/frontend/test/PaymentScreen.test.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import PaymentScreen from '../src/screens/PaymentScreen';
+import { UserProvider } from '../src/context/UserContext';
+
+describe('PaymentScreen', () => {
+  it('renders form inputs', () => {
+    const { getByText } = render(
+      <UserProvider>
+        <PaymentScreen />
+      </UserProvider>
+    );
+
+    expect(getByText('Monto')).toBeTruthy();
+  });
+});
+


### PR DESCRIPTION
## Summary
- add payments API service
- create payment screen with amount and method inputs
- register payment screen in navigation stacks

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68afae73ba08832ca0009783095eba52